### PR TITLE
Fix formatted string literal

### DIFF
--- a/lottery.py
+++ b/lottery.py
@@ -28,9 +28,10 @@ else:
         print(f"Your numbers are : {new_user_numbers}")
         cpu_numbers = draw_numbers()
         print(f"Drawn numbers : {cpu_numbers}")
-        matched_numbers = list(set(new_user_numbers).intersection(set(cpu_numbers)))
+        matched_numbers = list(set(new_user_numbers).intersection(set([cpu_numbers])))
         if len(matched_numbers) > 0:
-            print(f"You matched {len(matched_numbers)} number(s) !!")
-            print(f"Matched number(s) : {matched_numbers}")
+            number = "number" if len(matched_numbers) == 1 else "Numbers"
+            print(f"You matched {len(matched_numbers)} {number} !!")
+            print(f"Matched {number} : {matched_numbers}")
         else:
             print("You matched no numbers. Better luck next time!")

--- a/lottery.py
+++ b/lottery.py
@@ -30,7 +30,7 @@ else:
         print(f"Drawn numbers : {cpu_numbers}")
         matched_numbers = list(set(new_user_numbers).intersection(set([cpu_numbers])))
         if len(matched_numbers) > 0:
-            number = "number" if len(matched_numbers) == 1 else "Numbers"
+            number = "number" if len(matched_numbers) == 1 else "numbers"
             print(f"You matched {len(matched_numbers)} {number} !!")
             print(f"Matched {number} : {matched_numbers}")
         else:


### PR DESCRIPTION
Matching only one number, the message was `You matched 1 number(s) !!` </br>
![Captura de tela de 2024-03-25 17-03-03](https://github.com/leoGrz79/pythonlottery/assets/130297266/409e8dec-3d65-4d74-953d-290514312a42)

Now it is `You matched 1 number !!` instead. </br>
![Captura de tela de 2024-03-25 17-04-29](https://github.com/leoGrz79/pythonlottery/assets/130297266/840e330a-06e5-4662-ae53-b3e5be64f042)
